### PR TITLE
Fix off-by-one error in wrapping random walks

### DIFF
--- a/firmware/controller-128-no-clock/controller-128-no-clock.ino
+++ b/firmware/controller-128-no-clock/controller-128-no-clock.ino
@@ -264,7 +264,7 @@ struct Track {
         }
         else {
           current--;
-          if (current <= start) {
+          if (current < start) {
             current = (length - 1);
           }
         }
@@ -279,7 +279,7 @@ struct Track {
         }
         else {
           current--;
-          if (current <= start) {
+          if (current < start) {
             current = (length - 1);
           }
         }


### PR DESCRIPTION
Not tested, but I think it should work.
Fixes #23 